### PR TITLE
Replace setup with new Swift-only library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,15 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_13.2.app
       - name: test
         run: bazelisk test //...
-  # TODO: Re-enable when 5.7.1 is out
-  # linux-test:
-  #   name: Linux test
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: actions/checkout@v1
-  #     - uses: fwal/setup-swift@286618643423cd7921459c230b7cd8a96c9c7a10
-  #       with:
-  #         swift-version: "5.7"
-  #     - name: Get swift version
-  #       run: swift --version
-  #     - name: test
-  #       run: CC=clang bazelisk test --build_tests_only //test:swift_binary_test //test:swift_test
+  linux-test:
+    name: Linux test
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: fwal/setup-swift@286618643423cd7921459c230b7cd8a96c9c7a10
+        with:
+          swift-version: "5.7"
+      - name: Get swift version
+        run: swift --version
+      - name: test
+        run: CC=clang bazelisk test --build_tests_only //test:swift_binary_test //test:swift_test

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # swift-syntax-bazel
 
 This repo provides a bazel target for
-[`SwiftSyntax`](https://github.com/apple/swift-syntax). Most importantly
-it handles vendoring `lib_InternalSwiftSyntaxParser` as a static library
-so your tool doesn't depend on a specific Xcode.app path or version.
+[`SwiftSyntax`](https://github.com/apple/swift-syntax).
 
 ## Usage
 
 1. Make sure you've setup
-   [`rules_apple`](https://github.com/bazelbuild/rules_apple)
+   [`rules_swift`](https://github.com/bazelbuild/rules_swift)
 2. Go to the [releases
    page](https://github.com/keith/swift-syntax-bazel/releases) to grab
    the WORKSPACE snippet for the Xcode version you're using
@@ -19,18 +17,3 @@ so your tool doesn't depend on a specific Xcode.app path or version.
         "@com_github_keith_swift_syntax//:SwiftSyntax",
     ]
 ```
-
-## Details
-
-Previously if you built `SwiftSyntax` in your bazel build, the final
-binary would end up with a `rpath` like this:
-
-```
-/Applications/Xcode-12.4.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx
-```
-
-This meant if you used a remote bazel cache in your builds, everyone's
-Xcode path would have to match for this to work correctly. This repo
-links [a static
-binary](https://github.com/keith/StaticInternalSwiftSyntaxParser) for
-`lib_InternalSwiftSyntaxParser` instead.

--- a/SwiftSyntax.BUILD
+++ b/SwiftSyntax.BUILD
@@ -1,45 +1,96 @@
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@com_github_keith_swift_syntax_bazel//:opt_wrapper.bzl", "opt_wrapper")
 
 cc_library(
     name = "_CSwiftSyntax",
     srcs = glob(["Sources/_CSwiftSyntax/src/*.c"]),
     hdrs = glob(["Sources/_CSwiftSyntax/include/*.h"]),
-    copts = ["-Iexternal/com_github_keith_swift_syntax/Sources/_CSwiftSyntax/include"],
     linkstatic = True,
     tags = ["swift_module"],
 )
 
 swift_library(
-    name = "SwiftSyntax",
+    name = "SwiftSyntax_lib",
     srcs = glob(["Sources/SwiftSyntax/**/*.swift"]),
     module_name = "SwiftSyntax",
-    private_deps = ["_CSwiftSyntax"] + select({
-        "@platforms//os:macos": [
-            "@StaticInternalSwiftSyntaxParser//:lib_InternalSwiftSyntaxParser",
-        ],
-        "//conditions:default": [],
-    }),
+    private_deps = ["_CSwiftSyntax"],
+)
+
+opt_wrapper(
+    name = "SwiftSyntax",
     visibility = ["//visibility:public"],
+    deps = [
+        ":SwiftSyntax_lib",
+    ],
 )
 
 swift_library(
-    name = "SwiftSyntaxParser",
-    srcs = glob(["Sources/SwiftSyntaxParser/**/*.swift"]),
-    module_name = "SwiftSyntaxParser",
-    private_deps = select({
-        "@platforms//os:macos": [
-            "@StaticInternalSwiftSyntaxParser//:lib_InternalSwiftSyntaxParser",
-        ],
-        "//conditions:default": [],
-    }),
-    visibility = ["//visibility:public"],
-    deps = [":SwiftSyntax"],
+    name = "SwiftBasicFormat",
+    srcs = glob(["Sources/SwiftBasicFormat/**/*.swift"]),
+    module_name = "SwiftBasicFormat",
+    deps = [":SwiftSyntax_lib"],
 )
 
 swift_library(
-    name = "SwiftSyntaxBuilder",
+    name = "SwiftDiagnostics",
+    srcs = glob(["Sources/SwiftDiagnostics/**/*.swift"]),
+    module_name = "SwiftDiagnostics",
+    deps = [":SwiftSyntax_lib"],
+)
+
+swift_library(
+    name = "SwiftParser_lib",
+    srcs = glob(["Sources/SwiftParser/**/*.swift"]),
+    module_name = "SwiftParser",
+    deps = [
+        ":SwiftBasicFormat",
+        ":SwiftDiagnostics",
+        ":SwiftSyntax_lib",
+    ],
+)
+
+opt_wrapper(
+    name = "SwiftParser",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":SwiftParser_lib",
+    ],
+)
+
+swift_library(
+    name = "SwiftSyntaxBuilder_lib",
     srcs = glob(["Sources/SwiftSyntaxBuilder/**/*.swift"]),
     module_name = "SwiftSyntaxBuilder",
+    deps = [
+        ":SwiftBasicFormat",
+        ":SwiftParser_lib",
+        ":SwiftSyntax_lib",
+    ],
+)
+
+opt_wrapper(
+    name = "SwiftSyntaxBuilder",
     visibility = ["//visibility:public"],
-    deps = [":SwiftSyntax"],
+    deps = [
+        ":SwiftSyntaxBuilder_libSwiftParser_lib",
+    ],
+)
+
+swift_library(
+    name = "SwiftOperators_lib",
+    srcs = glob(["Sources/SwiftOperators/**/*.swift"]),
+    module_name = "SwiftOperators",
+    deps = [
+        ":SwiftDiagnostics",
+        ":SwiftParser_lib",
+        ":SwiftSyntax_lib",
+    ],
+)
+
+opt_wrapper(
+    name = "SwiftOperators",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":SwiftOperators_lib",
+    ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,8 +4,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "build_bazel_rules_apple",
-    sha256 = "36072d4f3614d309d6a703da0dfe48684ec4c65a89611aeb9590b45af7a3e592",
-    url = "https://github.com/bazelbuild/rules_apple/releases/download/1.0.1/rules_apple.1.0.1.tar.gz",
+    sha256 = "90e3b5e8ff942be134e64a83499974203ea64797fd620eddeb71b3a8e1bff681",
+    url = "https://github.com/bazelbuild/rules_apple/releases/download/1.1.2/rules_apple.1.1.2.tar.gz",
 )
 
 load(

--- a/deps.bzl
+++ b/deps.bzl
@@ -3,37 +3,13 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def swift_syntax_deps():
     """Fetches dependencies of SwiftSyntax"""
-    if not native.existing_rule("build_bazel_rules_apple"):
-        fail("error: this depends on rules_apple but that wasn't setup")
-
     if not native.existing_rule("build_bazel_rules_swift"):
         fail("error: this depends on rules_swift but that wasn't setup")
 
-    if not native.existing_rule("build_bazel_rules_apple"):
-        fail("error: this depends on rules_apple but that wasn't setup")
-
-    http_archive(
-        name = "StaticInternalSwiftSyntaxParser",
-        url = "https://github.com/keith/StaticInternalSwiftSyntaxParser/releases/download/5.7.1/lib_InternalSwiftSyntaxParser.xcframework.zip",
-        sha256 = "feb332ba0a027812b1ee7f552321d6069a46207e5cd0f64fa9bb78e2a261b366",
-        build_file_content = """
-load("@build_bazel_rules_apple//apple:apple.bzl", "apple_static_framework_import")
-
-apple_static_framework_import(
-    name = "lib_InternalSwiftSyntaxParser",
-    framework_imports = glob(
-        ["lib_InternalSwiftSyntaxParser.xcframework/macos-arm64_x86_64/lib_InternalSwiftSyntaxParser.framework/**"],
-        allow_empty = False,
-    ),
-    visibility = ["//visibility:public"],
-)
-""",
-    )
-
     http_archive(
         name = "com_github_keith_swift_syntax",
+        sha256 = "6a748d2118a5865116ccd1b099b566f6754514d7ecb83413e1cc2c46b5faa619",
         build_file = "@com_github_keith_swift_syntax_bazel//:SwiftSyntax.BUILD",
-        sha256 = "ea96dcd129ed4a05ea0efd7dbe39d929d47c55b1b5b8c2c7a8fce5c7de0bc4d8",
-        strip_prefix = "swift-syntax-0.50700.1",
-        url = "https://github.com/apple/swift-syntax/archive/refs/tags/0.50700.1.tar.gz",
+        strip_prefix = "swift-syntax-1bf320abf560142ce29967328033ae04d447774f",
+        url = "https://github.com/apple/swift-syntax/archive/1bf320abf560142ce29967328033ae04d447774f.tar.gz",
     )

--- a/opt_wrapper.bzl
+++ b/opt_wrapper.bzl
@@ -1,0 +1,53 @@
+"""
+A rule for forcing all dependent targets to be built in the opt configuration
+
+This is useful when you're using 'bazel run' with a target, but still want the
+benefits of compiler optimizations.
+"""
+
+load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo", "swift_common")
+
+def _force_opt_impl(settings, _attr):
+    return {
+        "//command_line_option:compilation_mode": "opt",
+        "//command_line_option:features": settings["//command_line_option:features"] + [
+            "-swift.opt_uses_osize",
+            "swift.opt_uses_wmo",
+        ],
+    }
+
+_force_opt = transition(
+    implementation = _force_opt_impl,
+    inputs = [
+        "//command_line_option:features",
+    ],
+    outputs = [
+        "//command_line_option:compilation_mode",
+        "//command_line_option:features",
+    ],
+)
+
+def _impl(ctx):
+    ccinfos = []
+    swiftinfos = []
+
+    for dep in ctx.attr.deps:
+        ccinfos.append(dep[CcInfo])
+        swiftinfos.append(dep[SwiftInfo])
+
+    return [
+        cc_common.merge_cc_infos(direct_cc_infos = ccinfos),
+        swift_common.create_swift_info(swift_infos = swiftinfos),
+    ]
+
+opt_wrapper = rule(
+    implementation = _impl,
+    attrs = {
+        "deps": attr.label_list(
+            cfg = _force_opt,
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+)

--- a/test/BUILD
+++ b/test/BUILD
@@ -5,14 +5,15 @@ swift_test(
     name = "swift_test",
     size = "small",
     srcs = ["swift_test.swift"],
-    deps = ["@com_github_keith_swift_syntax//:SwiftSyntaxParser"],
+    copts = ["-parse-as-library"],
+    deps = ["@com_github_keith_swift_syntax//:SwiftParser"],
 )
 
 swift_binary(
     name = "swift_binary",
     srcs = ["main.swift"],
     visibility = ["//visibility:public"],
-    deps = ["@com_github_keith_swift_syntax//:SwiftSyntaxParser"],
+    deps = ["@com_github_keith_swift_syntax//:SwiftParser"],
 )
 
 sh_test(
@@ -24,9 +25,10 @@ sh_test(
 
 swift_library(
     name = "macos_test_library",
+    testonly = True,
     srcs = ["macos_test_library.swift"],
     tags = ["manual"],
-    deps = ["@com_github_keith_swift_syntax//:SwiftSyntaxParser"],
+    deps = ["@com_github_keith_swift_syntax//:SwiftParser"],
 )
 
 macos_unit_test(
@@ -40,7 +42,7 @@ swift_library(
     name = "macos_binary_main",
     srcs = ["main.swift"],
     tags = ["manual"],
-    deps = ["@com_github_keith_swift_syntax//:SwiftSyntaxParser"],
+    deps = ["@com_github_keith_swift_syntax//:SwiftParser"],
 )
 
 macos_command_line_application(

--- a/test/macos_test_library.swift
+++ b/test/macos_test_library.swift
@@ -1,8 +1,8 @@
 import XCTest
-import SwiftSyntaxParser
+import SwiftParser
 
 final class TestLoad: XCTestCase {
     func testNoThrows() {
-        _ = try! SyntaxParser.parse(source: "/dev/null")
+        _ = try! Parser.parse(source: "/dev/null")
     }
 }

--- a/test/main.swift
+++ b/test/main.swift
@@ -1,3 +1,3 @@
-import SwiftSyntaxParser
+import SwiftParser
 
-_ = try! SyntaxParser.parse(source: "/dev/null")
+_ = try! Parser.parse(source: "/dev/null")

--- a/test/swift_test.swift
+++ b/test/swift_test.swift
@@ -1,14 +1,19 @@
 import XCTest
-import SwiftSyntaxParser
+import SwiftParser
 
 final class TestLoad: XCTestCase {
     func testNoThrows() {
-        _ = try! SyntaxParser.parse(source: "/dev/null")
+        _ = try! Parser.parse(source: "/dev/null")
     }
 }
 
 #if os(Linux)
-XCTMain([
-    testCase([("testNoThrows", TestLoad.testNoThrows)])
-])
+@main
+struct MainWrapper {
+    static func main() {
+        XCTMain([
+                testCase([("testNoThrows", TestLoad.testNoThrows)])
+        ])
+    }
+}
 #endif


### PR DESCRIPTION
This eliminates the need for handling the internal library, but is potentially still valuable to share this build file, and always force these targets to be built in the opt configuration to avoid performance issues when they're built in dbg