### PR TITLE
Remove _CSwiftSyntax

### DIFF
--- a/SwiftSyntax.BUILD
+++ b/SwiftSyntax.BUILD
@@ -1,14 +1,6 @@
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 load("@com_github_keith_swift_syntax_bazel//:opt_wrapper.bzl", "opt_wrapper")
 
-cc_library(
-    name = "_CSwiftSyntax",
-    srcs = glob(["Sources/_CSwiftSyntax/src/*.c"]),
-    hdrs = glob(["Sources/_CSwiftSyntax/include/*.h"]),
-    linkstatic = True,
-    tags = ["swift_module"],
-)
-
 swift_library(
     name = "SwiftSyntax_lib",
     srcs = glob(
@@ -16,7 +8,6 @@ swift_library(
         exclude = ["**/*.docc/**"],
     ),
     module_name = "SwiftSyntax",
-    private_deps = ["_CSwiftSyntax"],
 )
 
 opt_wrapper(


### PR DESCRIPTION
This library is gone but the globs were just ignoring that
